### PR TITLE
fix(#63): VS Code usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ It provides semantic highlighting and parsing error checking for `.eo` files
 (written in [EOLANG]).
 In order to use it, you need to have [Node] installed.
 
+## Using with VS Code
+
+As long as [VS Code] extensions are tightly integrated with the editor, so they handle LSP setup automatically. All you need is to open `Extensions Marketplace` (CTRL+SHIFT+X), type `eo` and install `EO` language extention for the EO Programming Language that provides syntax highlighting and parsing error checking out of the box. Now you're all set!
+
 ## Using with Sublime Text
 
 To use this [LSP] server with [Sublime Text], you'll need to install


### PR DESCRIPTION
@yegor256 Hi! Hope You are doing well!

After some time spending with searching info to solve this issue, I came to a conclusion that VS Code embed the LSP server or install it in the background after installing the `EO Extention` package, so you don’t need to manually configure it in the editor `User Settings (JSON)`, correct me if I'm wrong.