### PR TITLE
#324: clear semantic token builders on close

### DIFF
--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -153,6 +153,15 @@ export class SemanticTokensProvider {
     }
 
     /**
+     * Deletes the cached semantic token builder for the given document URI.
+     * @param uri - Text document URI whose cached builder should be removed
+     * @returns {void}
+     */
+    deleteTokenBuilder(uri: string) {
+        this.tokenBuilders.delete(uri);
+    }
+
+    /**
      * Pushes into a SemanticTokensBuilder the semantic tokens obtained from a text document
      * @param builder - SemanticTokensBuilder to be populated with the semantic tokens of the
      *                  given document

--- a/src/server.ts
+++ b/src/server.ts
@@ -204,6 +204,7 @@ connection.onDidChangeConfiguration(change => {
  */
 documents.onDidClose(e => {
     cache.delete(e.document.uri);
+    provider.deleteTokenBuilder(e.document.uri);
 });
 
 /**

--- a/test/semantic-token-cache.test.ts
+++ b/test/semantic-token-cache.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+jest.mock("../src/parser", () => ({
+    antlrTypeNumToString: jest.fn(() => ""),
+    getTokenTypes: jest.fn(() => []),
+    tokenize: jest.fn(() => [])
+}));
+
+import { SemanticTokensClientCapabilities } from "vscode-languageserver/node.js";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { SemanticTokensProvider } from "../src/semantics";
+
+describe("Semantic token builder cache", () => {
+    test("deletes the cached builder for a closed document", () => {
+        const capabilities: SemanticTokensClientCapabilities = {
+            tokenTypes: [],
+            tokenModifiers: [],
+            formats: [],
+            requests: { range: false, full: true }
+        };
+        const provider = new SemanticTokensProvider(capabilities);
+        const document = TextDocument.create("file:///closed.eo", "eo", 0, "# test.\n[] > test\n");
+        provider.getTokenBuilder(document);
+        provider.deleteTokenBuilder(document.uri);
+        expect(provider.tokenBuilders.has(document.uri)).toBeFalsy();
+    });
+});


### PR DESCRIPTION
Closes #324.

What changed:
- Adds a `deleteTokenBuilder(uri)` method to `SemanticTokensProvider`.
- Calls it from the existing `documents.onDidClose` handler, next to the document settings cache cleanup.
- Adds a focused regression test proving a cached builder is removed for a closed document URI.

Validation:
- `npx jest test/semantic-token-cache.test.ts --runInBand --coverage=false`
- `npx eslint src/semantics.ts src/server.ts test/semantic-token-cache.test.ts`
- `git diff --check`
- `gitleaks detect --source . --no-banner --redact --exit-code 1`

Limitations:
- Full local `make test` was not run because this Windows environment does not have `make` or `java`, so the generated ANTLR parser files cannot be produced here.
- `npx tsc --noEmit --pretty false` is blocked for the same generated-file reason: `src/parser/*` and `src/eo-version.ts` are absent in a fresh checkout until the Makefile generation step runs.