### PR TITLE
#321: handle optional semantic token capabilities

### DIFF
--- a/src/semantic-token-capability.ts
+++ b/src/semantic-token-capability.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { ClientCapabilities, SemanticTokensClientCapabilities } from "vscode-languageserver";
+
+export function semanticTokenClientCapabilities(
+    capabilities: ClientCapabilities
+): SemanticTokensClientCapabilities | undefined {
+    return capabilities.textDocument?.semanticTokens;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import { EoVersion } from "./eo-version";
 import { getParserErrors } from "./parser";
 import { Processor } from "./processor";
 import { SemanticTokensProvider } from "./semantics";
+import { semanticTokenClientCapabilities } from "./semantic-token-capability";
 
 /**
  * Connection with the server, using Node's IPC as a transport.
@@ -43,7 +44,7 @@ let clientCapsAnalyzer: ClientCapabilitiesAnalyzer;
 /**
  * Provider of the semantic highlighting capability of the language server.
  */
-let provider: SemanticTokensProvider;
+let provider: SemanticTokensProvider | undefined;
 
 /**
  * Defines procedures to be executed on the initialization process
@@ -51,7 +52,8 @@ let provider: SemanticTokensProvider;
  */
 connection.onInitialize((params: InitializeParams): InitializeResult => {
     clientCapsAnalyzer = new ClientCapabilitiesAnalyzer(params.capabilities);
-    provider = new SemanticTokensProvider(params.capabilities.textDocument!.semanticTokens!);
+    const semanticTokens = semanticTokenClientCapabilities(params.capabilities);
+    provider = semanticTokens ? new SemanticTokensProvider(semanticTokens) : undefined;
     const result: InitializeResult = {
         capabilities: {
             textDocumentSync: TextDocumentSyncKind.Incremental,
@@ -105,7 +107,7 @@ connection.onInitialized(() => {
             connection.console.log("Workspace folder change event received");
         });
     }
-    if (clientCapsAnalyzer.hasTokensSupport) {
+    if (clientCapsAnalyzer.hasTokensSupport && provider) {
         const options: SemanticTokensRegistrationOptions = {
             documentSelector: null,
             legend: provider.legend,
@@ -227,7 +229,7 @@ connection.onDidChangeWatchedFiles(_change => {
  */
 connection.languages.semanticTokens.on(params => {
     const document = documents.get(params.textDocument.uri);
-    if (!document) {
+    if (!document || !provider) {
         return { data: [] };
     }
     return provider.provideSemanticTokens(document);
@@ -239,7 +241,7 @@ connection.languages.semanticTokens.on(params => {
  */
 connection.languages.semanticTokens.onDelta(params => {
     const document = documents.get(params.textDocument.uri);
-    if (!document) {
+    if (!document || !provider) {
         return { data: [] };
     }
     return provider.provideDeltas(document);

--- a/test/semantic-token-capability.test.ts
+++ b/test/semantic-token-capability.test.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { ClientCapabilities, SemanticTokensClientCapabilities } from "vscode-languageserver";
+import { semanticTokenClientCapabilities } from "../src/semantic-token-capability";
+
+describe("Semantic token capability selection", () => {
+    test("returns nothing when text document capabilities are omitted", () => {
+        expect(semanticTokenClientCapabilities({})).toBeUndefined();
+    });
+
+    test("returns nothing when semantic tokens are omitted", () => {
+        expect(semanticTokenClientCapabilities({ textDocument: {} })).toBeUndefined();
+    });
+
+    test("returns advertised semantic token capabilities", () => {
+        const semanticTokens: SemanticTokensClientCapabilities = {
+            tokenTypes: ["class"],
+            tokenModifiers: [],
+            formats: [],
+            requests: { full: true },
+            multilineTokenSupport: false,
+            overlappingTokenSupport: false
+        };
+        const capabilities: ClientCapabilities = {
+            textDocument: {
+                semanticTokens
+            }
+        };
+
+        expect(semanticTokenClientCapabilities(capabilities)).toBe(semanticTokens);
+    });
+});


### PR DESCRIPTION
Closes #321.

Summary:
- avoid constructing `SemanticTokensProvider` when the client omits `textDocument.semanticTokens`
- reuse one helper for selecting advertised semantic-token capabilities
- guard semantic-token full/delta handlers when no provider was registered
- add focused coverage for omitted `textDocument`, omitted `semanticTokens`, and advertised semantic-token capabilities

Validation:
- RED: `npx jest test/semantic-token-capability.test.ts --runInBand --coverage=false` failed before the helper existed with `Cannot find module '../src/semantic-token-capability'`
- PASS: `npx jest test/semantic-token-capability.test.ts --runInBand --coverage=false`
- PASS: `npx eslint src/server.ts src/semantic-token-capability.ts test/semantic-token-capability.test.ts`
- PASS: `npx tsc --noEmit --pretty false --skipLibCheck --target es2020 --module commonjs --moduleResolution node --esModuleInterop --types jest src/semantic-token-capability.ts test/semantic-token-capability.test.ts`
- PASS: `git diff --check` and `git diff --cached --check`
- PASS: `gitleaks detect --source . --no-banner --redact --exit-code 1`

Limitations:
- `npx tsc --noEmit --pretty false` for the whole repository currently stops on missing generated files: `src/parser/EoParser`, `src/parser/EoLexer`, `src/parser/EoVisitor`, and `src/eo-version`.
- `make build` was not run locally because `make` is not installed in this Windows PowerShell environment.