### PR TITLE
#322: Convert semantic token offsets to UTF-16

### DIFF
--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -22,6 +22,40 @@ export type VSCodeToken = {
 }
 
 /**
+ * Builds a lookup table from code point offsets to UTF-16 offsets.
+ * @param text - Document text
+ * @returns - UTF-16 offset for each code point offset
+ */
+function codePointOffsetsToUtf16Offsets(text: string): number[] {
+    const offsets = [0];
+    for (const point of text) {
+        offsets.push(offsets[offsets.length - 1] + point.length);
+    }
+    return offsets;
+}
+
+/**
+ * Converts an ANTLR code point offset to a UTF-16 offset expected by LSP.
+ * @param offset - Code point offset
+ * @param offsets - Code point to UTF-16 lookup table
+ * @returns - UTF-16 offset
+ */
+function codePointOffsetToUtf16Offset(offset: number, offsets: number[]): number {
+    const index = Math.max(0, Math.min(offset, offsets.length - 1));
+    return offsets[index];
+}
+
+/**
+ * Converts an absolute UTF-16 offset to a UTF-16 line character position.
+ * @param text - Document text
+ * @param offset - Absolute UTF-16 offset
+ * @returns - UTF-16 character position inside the line
+ */
+function utf16OffsetInLine(text: string, offset: number): number {
+    return offset - text.lastIndexOf("\n", offset - 1) - 1;
+}
+
+/**
  * Responsible for dealing with semantic highlighting operations
  */
 export class SemanticTokensProvider {
@@ -119,17 +153,21 @@ export class SemanticTokensProvider {
      */
     tokenize(document: TextDocument): VSCodeToken[] {
         const tokens: VSCodeToken[] = [];
-        const antlrTokens = tokenize(document.getText());
+        const text = document.getText();
+        const utf16Offsets = codePointOffsetsToUtf16Offsets(text);
+        const antlrTokens = tokenize(text);
         antlrTokens.forEach(tk => {
             const vscodeTokenType = this.tokenTypeMap.get(antlrTypeNumToString(tk.type));
             const legend = vscodeTokenType ? this.legend.tokenTypes.indexOf(vscodeTokenType) : -1;
             if (legend === -1) {
                 return;
             }
+            const tokenStart = codePointOffsetToUtf16Offset(tk.start, utf16Offsets);
+            const tokenEnd = codePointOffsetToUtf16Offset(tk.stop + 1, utf16Offsets);
             tokens.push({
                 line: tk.line - 1,
-                start: tk.column,
-                length: tk.stop - tk.start + 1,
+                start: utf16OffsetInLine(text, tokenStart),
+                length: tokenEnd - tokenStart,
                 tokenType: legend,
                 tokenModifier: 0
             });

--- a/test/semantics-utf16.test.ts
+++ b/test/semantics-utf16.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { SemanticTokensClientCapabilities } from "vscode-languageserver/node.js";
+import { TextDocument } from "vscode-languageserver-textdocument";
+
+jest.mock("../src/parser", () => ({
+    antlrTypeNumToString: jest.fn(() => "NAME"),
+    getTokenTypes: jest.fn(() => new Set(["NAME"])),
+    tokenize: jest.fn(() => [{
+        line: 1,
+        column: 1,
+        start: 1,
+        stop: 3,
+        type: 1
+    }])
+}));
+
+import { SemanticTokensProvider } from "../src/semantics";
+
+describe("Semantic token UTF-16 positions", () => {
+    test("converts ANTLR code point offsets to LSP UTF-16 units", () => {
+        const clientCapabilities: SemanticTokensClientCapabilities = {
+            tokenTypes: ["variable"],
+            tokenModifiers: [],
+            formats: [],
+            requests: { full: true },
+            multilineTokenSupport: false,
+            overlappingTokenSupport: false
+        };
+        const provider = new SemanticTokensProvider(clientCapabilities);
+        const document = TextDocument.create("foo.eo", "eo", 0, "😀a😀b\n");
+        expect(provider.tokenize(document)).toEqual([{
+            line: 0,
+            start: 2,
+            length: 4,
+            tokenType: 0,
+            tokenModifier: 0
+        }]);
+    });
+});


### PR DESCRIPTION
Closes #322.

Summary:
- translate ANTLR code point offsets to UTF-16 offsets before building LSP semantic tokens
- use converted offsets for both token start and token length
- add a focused non-BMP regression for semantic token positioning

Validation:
- npx jest test/semantics-utf16.test.ts --runInBand --coverage=false
- npx eslint src/semantics.ts test/semantics-utf16.test.ts
- git diff --check
- git diff -- src/semantics.ts test/semantics-utf16.test.ts | gitleaks stdin --no-banner --redact --exit-code 1

Limitations:
- npx tsc --noEmit --pretty false is blocked in this fresh clone because generated src/parser/* and src/eo-version.ts are absent.
- npx jest test/semantics.test.ts --runInBand --coverage=false is blocked by the same missing generated parser files.
- This local Windows environment has no make/java available to generate those files.