### PR TITLE
#320: Catch configuration validation failures

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import { EoVersion } from "./eo-version";
 import { getParserErrors } from "./parser";
 import { Processor } from "./processor";
 import { SemanticTokensProvider } from "./semantics";
+import { validateTextDocuments } from "./validation";
 
 /**
  * Connection with the server, using Node's IPC as a transport.
@@ -196,7 +197,11 @@ connection.onDidChangeConfiguration(change => {
         const config = change.settings.languageServerExample;
         settings = (config && typeof config === "object") ? config : defaultSettings;
     }
-    documents.all().forEach(validateTextDocument);
+    validateTextDocuments(
+        documents.all(),
+        validateTextDocument,
+        message => connection.console.error(message)
+    );
 });
 
 /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { TextDocument } from "vscode-languageserver-textdocument";
+
+/**
+ * Validates every document and reports failures without dropping rejected promises.
+ * @param documents - Documents to validate
+ * @param validate - Validation callback
+ * @param report - Failure reporting callback
+ */
+export function validateTextDocuments(
+    documents: TextDocument[],
+    validate: (_document: TextDocument) => Promise<void>,
+    report: (_message: string) => void
+): void {
+    documents.forEach(document => {
+        validate(document).catch(error => {
+            report(`Validation failed for ${document.uri}: ${error}`);
+        });
+    });
+}

--- a/test/configuration-validation.test.ts
+++ b/test/configuration-validation.test.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { validateTextDocuments } from "../src/validation";
+
+describe("Configuration-triggered document validation", () => {
+    test("reports rejected document validations without stopping remaining validations", async () => {
+        const bad = TextDocument.create("file:///bad.eo", "eo", 0, "[] > bad\n");
+        const good = TextDocument.create("file:///good.eo", "eo", 0, "[] > good\n");
+        const validate = jest.fn()
+            .mockRejectedValueOnce(new Error("settings transport failed"))
+            .mockResolvedValueOnce(undefined);
+        const report = jest.fn();
+
+        validateTextDocuments([bad, good], validate, report);
+        await Promise.resolve();
+
+        expect(validate).toHaveBeenCalledTimes(2);
+        expect(validate).toHaveBeenNthCalledWith(1, bad);
+        expect(validate).toHaveBeenNthCalledWith(2, good);
+        expect(report).toHaveBeenCalledTimes(1);
+        expect(report).toHaveBeenCalledWith(
+            "Validation failed for file:///bad.eo: Error: settings transport failed"
+        );
+    });
+});


### PR DESCRIPTION
Closes #320.

Summary:
- route configuration-triggered document validation through a helper that catches rejected validations
- log each validation failure with the affected document URI instead of dropping the promise
- keep the rest of the configuration-change behavior unchanged

Validation:
- RED `npx jest test/configuration-validation.test.ts --runInBand --coverage=false` failed with `Expected number of calls: 2; Received number of calls: 0`
- GREEN `npx jest test/configuration-validation.test.ts --runInBand --coverage=false`
- `npx eslint src/server.ts src/validation.ts test/configuration-validation.test.ts`
- `npx tsc --noEmit --pretty false --skipLibCheck src/validation.ts test/configuration-validation.test.ts`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached | gitleaks stdin --no-banner --redact --exit-code 1`

Limitations:
- Full `npx tsc --noEmit --pretty false` is blocked in this fresh clone because generated `src/parser/*` files and `src/eo-version.ts` are absent.
- Full `npx jest --runInBand --coverage=false` is blocked until the server is built/generated: integration tests require `compiled/server.js`, and parser/AST tests require generated parser files.
- This local Windows environment has no `make` executable available to generate those files.