### PR TITLE
#319: Catch content validation failures

### DIFF
--- a/src/document-validation.ts
+++ b/src/document-validation.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { TextDocument } from "vscode-languageserver-textdocument";
+
+/**
+ * Validates a document without allowing validation failures to escape the LSP event handler.
+ * @param document - Document to validate
+ * @param validate - Validation procedure
+ * @param logger - LSP console logger
+ * @returns Promise that resolves after validation or failure logging
+ */
+export async function validateTextDocumentSafely(
+    document: TextDocument,
+    validate: (_document: TextDocument) => Promise<void>,
+    logger: { error: (_message: string) => void }
+): Promise<void> {
+    try {
+        await validate(document);
+    } catch (error) {
+        logger.error(`Validation failed for ${document.uri}: ${error}`);
+    }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import {
 } from "vscode-languageserver/node.js";
 import { ClientCapabilitiesAnalyzer } from "./capabilities";
 import { DefaultSettings } from "./defaultSettings";
+import { validateTextDocumentSafely } from "./document-validation";
 import { EoDocumentSymbol } from "./eoDocumentSymbol";
 import { EoVersion } from "./eo-version";
 import { getParserErrors } from "./parser";
@@ -211,7 +212,7 @@ documents.onDidClose(e => {
  * modified.
  */
 documents.onDidChangeContent(change => {
-    validateTextDocument(change.document);
+    validateTextDocumentSafely(change.document, validateTextDocument, connection.console);
 });
 
 /**

--- a/test/document-validation.test.ts
+++ b/test/document-validation.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import * as fs from "fs";
+import * as path from "path";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { validateTextDocumentSafely } from "../src/document-validation";
+
+describe("Document validation safety", () => {
+    test("reports validation rejection without rethrowing", async () => {
+        const document = TextDocument.create("file:///broken.eo", "eo", 1, "[] > broken\n");
+        const validate = jest.fn((_document: TextDocument) => Promise.reject(new Error("settings unavailable")));
+        const logger = { error: jest.fn() };
+
+        await expect(validateTextDocumentSafely(document, validate, logger)).resolves.toBeUndefined();
+
+        expect(validate).toHaveBeenCalledWith(document);
+        expect(logger.error).toHaveBeenCalledWith(
+            "Validation failed for file:///broken.eo: Error: settings unavailable"
+        );
+    });
+
+    test("document content changes use safe validation", () => {
+        const server = fs.readFileSync(path.join(__dirname, "..", "src", "server.ts"), "utf8");
+
+        expect(server).toContain(
+            "validateTextDocumentSafely(change.document, validateTextDocument, connection.console);"
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- add a small document-validation wrapper that catches rejected validation promises
- route `documents.onDidChangeContent` through the wrapper so a failed validation is logged instead of becoming an unhandled rejection
- cover the wrapper behavior and the server wiring with a focused regression

## Validation
- RED `npx jest test/document-validation.test.ts --runInBand --coverage=false` failed before implementation with `Cannot find module '../src/document-validation'`
- GREEN `npx jest test/document-validation.test.ts --runInBand --coverage=false`
- `npx eslint src/server.ts src/document-validation.ts test/document-validation.test.ts`
- `npx tsc --noEmit --pretty false --skipLibCheck src/document-validation.ts test/document-validation.test.ts`
- `git diff --check`
- `git diff --cached --check`
- `git diff --cached | gitleaks stdin --no-banner --redact --exit-code 1`

## Limitations
- Full `npx tsc --noEmit --pretty false` is still blocked because generated parser files and `src/eo-version.ts` are absent in the checkout.
- Full `npx jest --runInBand --coverage=false` is still blocked because integration tests require `compiled/server.js` from `make build`, and parser-related suites require generated parser files.
- Local `make` and `java` are not available on this machine.