### PR TITLE
#65 add neovim usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,34 @@ contexts:
 
 Should work. If it doesn't, [file an issue], we'll help.
 
+## Using with Neovim
+
+To use this [LSP] server with [Neovim], you need [Neovim] 0.11 or later
+(the built-in LSP client, no plugin required).
+
+First, tell Neovim that `*.eo` files use the `eo` filetype, by adding
+this to your `init.lua`:
+
+```lua
+vim.filetype.add({ extension = { eo = 'eo' } })
+```
+
+Then, register the server and enable it:
+
+```lua
+vim.lsp.config['eo_lsp'] = {
+  cmd = { 'npx', '-y', 'eo-lsp-server@0.4.0', '--stdio' },
+  filetypes = { 'eo' },
+  root_markers = { '.git', '.eo-root' },
+}
+vim.lsp.enable('eo_lsp')
+```
+
+Open any `*.eo` file; the server starts on attach and provides
+semantic tokens and diagnostics.
+
+Should work. If it doesn't, [file an issue], we'll help.
+
 ## How to Contribute
 
 First, install [Node] modules with:
@@ -107,3 +135,4 @@ Create a pull request, we'll be glad to review it and merge.
 [lsp4ij-doc]: https://github.com/redhat-developer/lsp4ij/blob/main/docs/user-defined-ls/eo-lsp-server.md
 [IntelliJ]: https://www.jetbrains.com/idea/
 [npm]: https://www.npmjs.com/
+[Neovim]: https://neovim.io/


### PR DESCRIPTION
The README explains how to use the server with IntelliJ and Sublime Text but not with Neovim. Issue #65 asks for that section.

This patch adds a `## Using with Neovim` block to README.md, modeled on the existing Sublime Text section. It tells the reader to register the filetype with `vim.filetype.add`, declare the server via `vim.lsp.config['eo_lsp']`, and enable it with `vim.lsp.enable`. The instructions target the built-in LSP client in Neovim 0.11+, so no third-party plugin is required. The change is documentation-only; no source files are touched.

The repository build is currently broken on master (see #344: `ANTLR4_VERSION` overwritten with `0.61.0`), so this branch inherits the same CI failure on the ANTLR jar download step. No new lint, type, or test signal is introduced by this change. Local \`make lint\` was not run because the same Makefile breakage blocks the dependency download path.

Closes #65