### PR TITLE
fix(#340): rename leftover languageServerExample config section to eo

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -147,7 +147,7 @@ function getDocumentSettings(resource: string): Thenable<DefaultSettings> {
     if (!result) {
         result = connection.workspace.getConfiguration({
             scopeUri: resource,
-            section: "languageServerExample"
+            section: "eo"
         }).then(config => ((config && typeof config === "object") ? config : defaultSettings));
         cache.set(resource, result);
     }
@@ -194,7 +194,7 @@ connection.onDidChangeConfiguration(change => {
     if (clientCapsAnalyzer.hasConfigurationSupport) {
         cache.clear();
     } else {
-        const config = change.settings.languageServerExample;
+        const config = change.settings.eo;
         settings = (config && typeof config === "object") ? config : defaultSettings;
     }
     validateTextDocuments(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -354,7 +354,7 @@ describe("LSP Server Integration", () => {
         sendNotification("initialized", {});
         sendNotification("workspace/didChangeConfiguration", {
             settings: {
-                languageServerExample: null
+                eo: null
             }
         });
         const uri = "file:///malformed.eo";
@@ -385,5 +385,50 @@ describe("LSP Server Integration", () => {
         });
         const diagnostics = await diagnosticsPromise;
         expect(Array.isArray(diagnostics)).toBeTruthy();
+    }, 15000);
+
+    test("Server reads the diagnostics limit from the eo configuration section", async () => {
+        await sendRequest("initialize", {
+            processId: process.pid,
+            rootUri: null,
+            capabilities: {
+                workspace: {
+                    configuration: false
+                },
+                textDocument: {
+                    semanticTokens: {
+                        tokenTypes: [],
+                        tokenModifiers: []
+                    }
+                }
+            }
+        });
+        sendNotification("initialized", {});
+        sendNotification("workspace/didChangeConfiguration", {
+            settings: {
+                eo: { limit: 0 }
+            }
+        });
+        const uri = "file:///eo-section.eo";
+        const diagnosticsPromise = new Promise(resolve => {
+            const handler = (message: any) => {
+                if (message.method === "textDocument/publishDiagnostics" &&
+                    message.params.uri === uri) {
+                    notifications = notifications.filter(h => h !== handler);
+                    resolve(message.params.diagnostics);
+                }
+            };
+            notifications.push(handler);
+        });
+        sendNotification("textDocument/didOpen", {
+            textDocument: {
+                uri,
+                languageId: "eo",
+                version: 1,
+                text: "-- broken --"
+            }
+        });
+        const diagnostics = await diagnosticsPromise;
+        expect((diagnostics as any[]).length).toBe(0);
     }, 15000);
 });


### PR DESCRIPTION
The server read its settings under the section name `languageServerExample`, the placeholder left over from Microsoft's `lsp-sample` template the project was scaffolded from. That string was used in two places in `src/server.ts`: the `workspace/configuration` request in `getDocumentSettings`, and the `change.settings` lookup in the `onDidChangeConfiguration` fallback. As a result the server's only real setting, the `limit` on reported diagnostics, could only be overridden under a block literally named `languageServerExample`, which is undiscoverable and unrelated to EO.

This renames the section to `eo` in both spots, matching the `eo` language id and the `.eo` extension. The malformed-configuration integration test is updated to the new key, and a new integration test sends `{ eo: { limit: 0 } }` over `didChangeConfiguration` and asserts the server then reports zero diagnostics for broken input, which pins the section name to the actual behavior.

I left `package.json` alone: this server ships as an npm package consumed over stdio by Sublime, Neovim and IntelliJ (LSP4IJ), not as a VS Code extension, so there is no `contributes.configuration` manifest to declare here. Happy to add documentation of the `eo` settings block to the README as a follow-up if that is wanted.

Closes #340
