### PR TITLE
Add native-JS span factory as first brick of the line-based parser

### DIFF
--- a/src/span.js
+++ b/src/span.js
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+/**
+ * One source line of an EO program.
+ *
+ * A span is the smallest unit the line-based EO parser works with: it carries
+ * a single line of text together with its one-indexed number, and answers
+ * questions about the line's leading whitespace, indentation and body. This is
+ * the first native-JavaScript building block of the parser that will replace
+ * the ANTLR-generated one.
+ *
+ * @param chars - Line text without the trailing terminator
+ * @param number - One-indexed source line number
+ * @returns - A frozen span object
+ */
+export function span(chars, number) {
+    const indent = () => {
+        let count = 0;
+        while (count < chars.length && chars.charAt(count) === " ") {
+            count = count + 1;
+        }
+        return count;
+    };
+    const tab = () => {
+        let found = false;
+        for (let idx = 0; idx < chars.length; idx = idx + 1) {
+            const glyph = chars.charAt(idx);
+            if (glyph === "\t") {
+                found = true;
+                break;
+            }
+            if (glyph !== " ") {
+                break;
+            }
+        }
+        return found;
+    };
+    return Object.freeze({
+        text: () => chars,
+        line: () => number,
+        indent,
+        tab,
+        blank: () => indent() === chars.length,
+        body: () => chars.substring(indent())
+    });
+}
+
+/*
+ * @todo #352:60 Implement a tokens reader factory in native JavaScript that
+ *  consumes a span and exposes a moving cursor with read methods for
+ *  identifiers, integers, star tuples and method-dispatch chains, mirroring
+ *  the upstream line-based parser, so the language server can tokenize EO
+ *  source without the ANTLR-generated parser. Cover it with tests.
+ */

--- a/test/span.test.js
+++ b/test/span.test.js
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { span } from "../src/span";
+
+describe("span", () => {
+    test("keeps the original line text untouched", () => {
+        expect(span("  42 > @", 7).text()).toBe("  42 > @");
+    });
+    test("reports its one-indexed line number", () => {
+        expect(span("[] > app", 13).line()).toBe(13);
+    });
+    test("counts the leading spaces as indent", () => {
+        expect(span("    stdout", 4).indent()).toBe(4);
+    });
+    test("does not treat an unindented line as indented", () => {
+        expect(span("# comment", 1).indent()).toBe(0);
+    });
+    test("considers a whitespace-only line blank", () => {
+        expect(span("      ", 9).blank()).toBe(true);
+    });
+    test("does not consider a line with content blank", () => {
+        expect(span("  x > y", 2).blank()).toBe(false);
+    });
+    test("strips the leading whitespace from the body", () => {
+        expect(span("    foo > bar", 5).body()).toBe("foo > bar");
+    });
+    test("spots a tab hiding in the leading whitespace", () => {
+        expect(span("\tnope", 6).tab()).toBe(true);
+    });
+    test("finds no tab when the line starts with content", () => {
+        expect(span("plus > x", 3).tab()).toBe(false);
+    });
+    test("finds no tab in a line of only spaces", () => {
+        expect(span("   ", 8).tab()).toBe(false);
+    });
+});


### PR DESCRIPTION
EO 0.61.1 dropped the ANTLR grammar this server generates its parser from, so the project cannot follow upstream while it stays coupled to ANTLR. This is the first step of moving the parser to native JavaScript, taken one small piece at a time under PDD.

It adds a `span` factory: the smallest unit of the new line-based parser, holding a single source line and answering what its text, line number, indent, body and leading tab are. The change is purely additive — no existing ANTLR or TypeScript code is touched yet, so the current build keeps working untouched. Removal of the old parser comes at the end of the migration.

A `@todo` puzzle is left for the next brick: a tokens reader that walks a span. Tests cover the new factory in full.

Closes #352
