### PR TITLE
fix(#336): drop four unused client-capability fields

### DIFF
--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,25 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-import { ClientCapabilities, SymbolKind, SymbolTag } from "vscode-languageserver";
+import { ClientCapabilities } from "vscode-languageserver";
 
 export class ClientCapabilitiesAnalyzer {
     public readonly hasConfigurationSupport: boolean;
     public readonly hasWorkspaceFolderSupport: boolean;
-    public readonly hasDiagnosticsSupport: boolean;
     public readonly hasTokensSupport: boolean;
-    public readonly hasHierarchicalDocumentSymbolSupport: boolean;
-    public readonly hasSymbolKindsSupport: SymbolKind[] | undefined;
-    public readonly hasSymbolTagsSupport: SymbolTag[] | undefined;
 
     constructor(capabilities: ClientCapabilities) {
         this.hasConfigurationSupport = !!capabilities.workspace?.configuration;
         this.hasWorkspaceFolderSupport = !!capabilities.workspace?.workspaceFolders;
-        this.hasDiagnosticsSupport = !!capabilities.textDocument?.publishDiagnostics?.relatedInformation;
         this.hasTokensSupport = !!capabilities.textDocument?.semanticTokens;
-        const documentSymbolCapabilities = capabilities.textDocument?.documentSymbol;
-        this.hasHierarchicalDocumentSymbolSupport = !!documentSymbolCapabilities?.hierarchicalDocumentSymbolSupport;
-        this.hasSymbolKindsSupport = documentSymbolCapabilities?.symbolKind?.valueSet;
-        this.hasSymbolTagsSupport = documentSymbolCapabilities?.tagSupport?.valueSet;
     }
 }

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { ClientCapabilities } from "vscode-languageserver";
+import { ClientCapabilitiesAnalyzer } from "../src/capabilities";
+
+describe("Client capabilities analyzer", () => {
+    test("reads configuration support from the client", () => {
+        const analyzer = new ClientCapabilitiesAnalyzer({
+            workspace: { configuration: true }
+        } as ClientCapabilities);
+        expect(analyzer.hasConfigurationSupport).toBe(true);
+    });
+    test("reports missing configuration support as false", () => {
+        const analyzer = new ClientCapabilitiesAnalyzer({} as ClientCapabilities);
+        expect(analyzer.hasConfigurationSupport).toBe(false);
+    });
+    test("reads workspace folder support from the client", () => {
+        const analyzer = new ClientCapabilitiesAnalyzer({
+            workspace: { workspaceFolders: true }
+        } as ClientCapabilities);
+        expect(analyzer.hasWorkspaceFolderSupport).toBe(true);
+    });
+    test("reads semantic tokens support from the client", () => {
+        const analyzer = new ClientCapabilitiesAnalyzer({
+            textDocument: { semanticTokens: { dynamicRegistration: false, requests: {}, tokenTypes: [], tokenModifiers: [], formats: [] } }
+        } as ClientCapabilities);
+        expect(analyzer.hasTokensSupport).toBe(true);
+    });
+    test("exposes no fields beyond the three negotiated supports", () => {
+        const analyzer = new ClientCapabilitiesAnalyzer({} as ClientCapabilities);
+        expect(Object.keys(analyzer).sort()).toStrictEqual(
+            ["hasConfigurationSupport", "hasTokensSupport", "hasWorkspaceFolderSupport"]
+        );
+    });
+});


### PR DESCRIPTION
The constructor of `ClientCapabilitiesAnalyzer` populated seven fields, but only three were ever read (`hasConfigurationSupport`, `hasWorkspaceFolderSupport`, `hasTokensSupport`, all consumed in `src/server.ts`). The remaining four were written and never looked at again.

This drops `hasDiagnosticsSupport`, `hasHierarchicalDocumentSymbolSupport`, `hasSymbolKindsSupport`, and `hasSymbolTagsSupport` along with their assignments. The last two were also misleading: named `has...Support` as if booleans while actually holding `SymbolKind[] | undefined` and `SymbolTag[] | undefined`. The now-unused `SymbolKind` and `SymbolTag` imports go with them.

A new `test/capabilities.test.ts` pins the three negotiated supports the analyzer must keep, including a check that no other fields leak onto it. If symbol-kind/tag negotiation is later needed for the document-symbol provider, it should be wired into `EoDocumentSymbol` rather than parked on the analyzer.

Closes #336 and should be reviewed once #352 issue is solved 
