### PR TITLE
fix(#337): drop dead limit !== null diagnostics guard

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver/node.js";
+import { ParserError } from "./parserError";
+
+/**
+ * Builds the diagnostics for a document, reporting parser errors up to the limit.
+ * @param errors - Parser errors found in the document
+ * @param limit - Maximum number of diagnostics to report
+ * @param version - EO grammar version stamped onto each message
+ * @returns Diagnostics capped at the limit
+ */
+export function diagnostics(errors: ParserError[], limit: number, version: string): Diagnostic[] {
+    const reported: Diagnostic[] = [];
+    errors.forEach((error, index) => {
+        if (index >= limit) {
+            return;
+        }
+        reported.push({
+            severity: DiagnosticSeverity.Error,
+            range: {
+                start: { line: error.line - 1, character: error.column },
+                end: { line: error.line - 1, character: error.column }
+            },
+            message: `${error.msg} (EO ${version})`,
+            source: "ex"
+        });
+    });
+    return reported;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,8 +4,6 @@
 import { TextDocument } from "vscode-languageserver-textdocument";
 import {
     createConnection,
-    Diagnostic,
-    DiagnosticSeverity,
     DidChangeConfigurationNotification,
     DocumentSymbolParams,
     InitializeParams,
@@ -18,6 +16,7 @@ import {
 } from "vscode-languageserver/node.js";
 import { ClientCapabilitiesAnalyzer } from "./capabilities";
 import { DefaultSettings } from "./defaultSettings";
+import { diagnostics } from "./diagnostics";
 import { EoDocumentSymbol } from "./eoDocumentSymbol";
 import { EoVersion } from "./eo-version";
 import { getParserErrors } from "./parser";
@@ -164,26 +163,10 @@ function getDocumentSettings(resource: string): Thenable<DefaultSettings> {
 async function validateTextDocument(document: TextDocument): Promise<void> {
     const config = await getDocumentSettings(document.uri);
     const text = document.getText();
-    const diagnostics: Diagnostic[] = [];
     const errors = getParserErrors(text);
     const effective = config || defaultSettings;
-    const limit = effective.limit;
-    errors.forEach((error, index) => {
-        if (limit !== null && index >= limit) {
-            return;
-        }
-        const diagnostic: Diagnostic = {
-            severity: DiagnosticSeverity.Error,
-            range: {
-                start: { line: error.line - 1, character: error.column },
-                end: { line: error.line - 1, character: error.column }
-            },
-            message: `${error.msg} (EO ${EoVersion})`,
-            source: "ex"
-        };
-        diagnostics.push(diagnostic);
-    });
-    connection.sendDiagnostics({ uri: document.uri, diagnostics });
+    const reported = diagnostics(errors, effective.limit, EoVersion);
+    connection.sendDiagnostics({ uri: document.uri, diagnostics: reported });
 }
 
 /**

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { ParserError } from "../src/parserError";
+import { diagnostics } from "../src/diagnostics";
+
+describe("Capped diagnostics builder", () => {
+    test("caps reported diagnostics at the given limit", () => {
+        const errors = [
+            new ParserError(3, 7, "first"),
+            new ParserError(5, 1, "second"),
+            new ParserError(9, 4, "third")
+        ];
+        expect(diagnostics(errors, 2, "0.57.3").length).toBe(2);
+    });
+    test("reports nothing when the limit is zero", () => {
+        const errors = [new ParserError(2, 6, "lonely")];
+        expect(diagnostics(errors, 0, "0.57.3").length).toBe(0);
+    });
+    test("reports every error when the limit exceeds the count", () => {
+        const errors = [new ParserError(4, 2, "alpha"), new ParserError(8, 0, "beta")];
+        expect(diagnostics(errors, 50, "0.57.3").length).toBe(2);
+    });
+    test("places a diagnostic one line above its parser error", () => {
+        const errors = [new ParserError(11, 4, "shifted")];
+        expect(diagnostics(errors, 1, "0.57.3")[0].range.start.line).toBe(10);
+    });
+    test("stamps the eo version onto the diagnostic message", () => {
+        const errors = [new ParserError(6, 3, "broken token")];
+        expect(diagnostics(errors, 1, "0.57.3")[0].message).toBe("broken token (EO 0.57.3)");
+    });
+});


### PR DESCRIPTION
The diagnostics loop in `validateTextDocument` capped reported problems with `if (limit !== null && index >= limit)`. But `limit` comes from `effective.limit`, and `DefaultSettings.limit` is typed `number`, so it can never be null. The `limit !== null` half was always true and did nothing — leftover from an earlier design where a null limit meant "no cap".

I matched the code to the type by reducing the guard to `index >= limit`. While here, the capping logic moved out of the server into a small `src/diagnostics.ts` module, so `validateTextDocument` now just delegates to it and the now-unused `Diagnostic`/`DiagnosticSeverity` imports are gone. That also makes the cap testable on its own.

`test/diagnostics.test.ts` covers the cap at the limit, the zero-limit case, an over-count limit, the one-line offset, and the version stamp on the message.

Closes #337 and should be reviewed once #352 issue is solved.
