### PR TITLE
fix(#323): widen parser-error range to offending token length

### DIFF
--- a/src/errorListener.ts
+++ b/src/errorListener.ts
@@ -23,6 +23,7 @@ export class ErrorListener implements ANTLRErrorListener<AntlrToken> {
 
     syntaxError(recognizer: Recognizer<AntlrToken>, symbol: AntlrToken | undefined, line: number,
         position: number, msg: string, _e: RecognitionException | undefined) {
-        this.errors.push(new ParserError(line, position, msg));
+        const length = symbol && symbol.stop >= symbol.start ? symbol.stop - symbol.start + 1 : 1;
+        this.errors.push(new ParserError(line, position, length, msg));
     }
 }

--- a/src/parserError.ts
+++ b/src/parserError.ts
@@ -9,18 +9,21 @@
 export class ParserError {
     line: number;
     column: number;
+    length: number;
     msg: string;
 
     /**
      * Error class constructor
      * @param line - Line number of error
      * @param column - Column number of error
+     * @param length - Length of the offending token in characters, or 1 when unknown
      * @param msg - Error message
      * @returns - ParserError object
      */
-    constructor(line: number, column: number, msg: string) {
+    constructor(line: number, column: number, length: number, msg: string) {
         this.line = line;
         this.column = column;
+        this.length = length;
         this.msg = msg;
     }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -176,7 +176,7 @@ async function validateTextDocument(document: TextDocument): Promise<void> {
             severity: DiagnosticSeverity.Error,
             range: {
                 start: { line: error.line - 1, character: error.column },
-                end: { line: error.line - 1, character: error.column }
+                end: { line: error.line - 1, character: error.column + error.length }
             },
             message: `${error.msg} (EO ${EoVersion})`,
             source: "ex"

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { antlrTypeNumToString, getTokenTypes, getParserErrors, buildTokenSetAndMap, resetTokenCache } from "../src/parser";
+import { ErrorListener } from "../src/errorListener";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -33,6 +34,23 @@ describe("Parser module", () => {
     test("detects parsing errors", () => {
         const errors = getParserErrors("-- broken syntax --");
         expect(errors.length).toBe(1);
+    });
+
+    test("parser errors carry the offending token length so diagnostic ranges are non-empty", () => {
+        const errors = getParserErrors("-- broken syntax --");
+        expect(errors.length).toBeGreaterThan(0);
+        errors.forEach(error => {
+            expect(error.length).toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    test("error listener falls back to length one when ANTLR omits the offending token", () => {
+        const listener = new ErrorListener();
+        listener.syntaxError(undefined as never, undefined, 3, 7, "boom", undefined);
+        expect(listener.errors).toHaveLength(1);
+        expect(listener.errors[0].length).toBe(1);
+        expect(listener.errors[0].line).toBe(3);
+        expect(listener.errors[0].column).toBe(7);
     });
 
     test("parses fibonacci program from file", () => {


### PR DESCRIPTION
This addresses #323. The diagnostics loop in `validateTextDocument` built a Range whose `end` matched `start`, which produced zero-length squiggles that VSCode renders as an invisible caret and that some other LSP clients drop entirely.

The fix derives the offending token's length inside `ErrorListener.syntaxError` from the ANTLR symbol when one is supplied, falls back to one character when ANTLR omits the symbol, and threads that length through `ParserError` so the diagnostic Range ends at `column + length`. Clients now paint a real squiggle on every parser error instead of a hidden caret.

`make` runs end to end on the branch: parser generation, `tsc -b`, `ncc` bundle, 40 jest tests at 100 percent statement and 100 percent branch coverage on `errorListener.ts`, and `eslint src --ext .ts` clean. A new test in `test/parser.test.ts` pins that every `ParserError` carries a length of at least one, and a unit test exercises the `symbol === undefined` fallback path.

Closes #323
