### PR TITLE
fix(#338): drop redundant effective fallback in validateTextDocument

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -166,8 +166,7 @@ async function validateTextDocument(document: TextDocument): Promise<void> {
     const text = document.getText();
     const diagnostics: Diagnostic[] = [];
     const errors = getParserErrors(text);
-    const effective = config || defaultSettings;
-    const limit = effective.limit;
+    const limit = config.limit;
     errors.forEach((error, index) => {
         if (limit !== null && index >= limit) {
             return;


### PR DESCRIPTION
getDocumentSettings already guarantees a real DefaultSettings object on every path: the no-configuration branch returns the cached settings, and the configuration branch falls back to defaultSettings inside its own .then. By the time validateTextDocument reads it, config can never be null or undefined, so the outer 'effective = config || defaultSettings' alias on src/server.ts:169 is a fallback that can never fire.

This drops the dead alias and reads the limit straight from config. The genuine default handling stays inside getDocumentSettings, where it belongs.

Ran 'make build', 'make test' (38 tests pass, coverage unchanged), and 'make lint' locally. Build needed Eo.g4 fetched from the 0.61.0 tag because the 0.61.1 tag no longer hosts the grammar file (see #366 and PR #367) - unrelated to this change.

Closes #338