### PR TITLE
Bump copyright year to 2024-2026 across LICENSE and headers

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/grammar-up.yml
+++ b/.github/workflows/grammar-up.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length

--- a/Eo.g4
+++ b/Eo.g4
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 grammar Eo;

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2024-2025 Objectionary.com
+Copyright (c) 2024-2026 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2024-2025 Objectionary.com
+Copyright (c) 2024-2026 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 
 .PHONY: all build test lint clean

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 module.exports = {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 const eslint = require("@eslint/js");

--- a/fixtures/fibonacci.eo
+++ b/fixtures/fibonacci.eo
@@ -1,5 +1,5 @@
 +home https://www.eolang.org
-+spdx SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
++spdx SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Fibonacci number.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 /*

--- a/src/IndentationLexer.ts
+++ b/src/IndentationLexer.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { Token, CommonToken, Lexer, CharStream } from "antlr4";

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { ClientCapabilities, SymbolKind, SymbolTag } from "vscode-languageserver";

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 /**

--- a/src/eoAst.ts
+++ b/src/eoAst.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { Range } from "vscode-languageserver";

--- a/src/eoDocumentSymbol.ts
+++ b/src/eoDocumentSymbol.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import {

--- a/src/errorListener.ts
+++ b/src/errorListener.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import * as fs from "fs";

--- a/src/parserError.ts
+++ b/src/parserError.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 /**

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import {

--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { TextDocument } from "vscode-languageserver-textdocument";

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { TextDocument } from "vscode-languageserver-textdocument";

--- a/test/compatibility.test.ts
+++ b/test/compatibility.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 describe("Node.js version compatibility", () => {

--- a/test/configuration-validation.test.ts
+++ b/test/configuration-validation.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { TextDocument } from "vscode-languageserver-textdocument";

--- a/test/eo-ast.test.ts
+++ b/test/eo-ast.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { EoAst, EoAstNode } from "../src/eoAst";

--- a/test/indentation-lexer.test.ts
+++ b/test/indentation-lexer.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { CharStreams, Token } from "antlr4";

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { spawn, ChildProcess } from "child_process";

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { antlrTypeNumToString, getTokenTypes, getParserErrors, buildTokenSetAndMap, resetTokenCache } from "../src/parser";

--- a/test/semantic-token-cache.test.ts
+++ b/test/semantic-token-cache.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 jest.mock("../src/parser", () => ({

--- a/test/semantics.test.ts
+++ b/test/semantics.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { SemanticTokensProvider } from "../src/semantics";


### PR DESCRIPTION
The `copyrights` check matches every file against the exact `Copyright` line in `LICENSE.txt`, which read `Copyright (c) 2024-2025 Objectionary.com`. The match is a literal substring test, not a year-range comparison, so once the calendar reached 2026 any file stamped with the current year was rejected as a mismatch.

This bumps `LICENSE.txt` and all 40 file headers from `2024-2025` to `2024-2026`, so the punch line tracks the calendar and current-year notices pass. Nothing else changes: each file differs by the single year on its copyright line, and `make all` stays green.

Doing the same bump every January keeps the line from trailing the year again.

Closes #368
