### PR TITLE
Read tab-indentation errors with a native line reader

### DIFF
--- a/src/lines.js
+++ b/src/lines.js
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+/**
+ * Reads one source line into its indentation facts.
+ * @param {string} text - One line, without its newline terminator
+ * @param {number} line - 1-based line number
+ * @returns {{line: number, indent: number, tab: boolean, blank: boolean, body: string}} Its facts
+ */
+const span = (text, line) => {
+  let indent = 0;
+  while (indent < text.length && text[indent] === " ") {
+    indent += 1;
+  }
+  let tab = false;
+  for (let idx = 0; idx < text.length; idx += 1) {
+    if (text[idx] === "\t") {
+      tab = true;
+      break;
+    }
+    if (text[idx] !== " ") {
+      break;
+    }
+  }
+  return { line, indent, tab, blank: indent === text.length, body: text.slice(indent) };
+};
+
+/**
+ * Whether the line opens a text block: a bare """ trailed only by whitespace.
+ * @param {{blank: boolean, body: string}} one - A span
+ * @returns {boolean} True if it opens a text block
+ */
+const opensTextBlock = (one) =>
+  !one.blank
+  && one.body.startsWith('"""')
+  && [...one.body.slice(3)].every((glyph) => glyph === " " || glyph === "\t");
+
+/**
+ * Whether the line closes the open text block: a """ at the opener's indent.
+ * @param {{blank: boolean, indent: number, body: string}} one - A span
+ * @param {number} openIndent - Indent the text block opened at
+ * @returns {boolean} True if it closes the text block
+ */
+const closesTextBlock = (one, openIndent) =>
+  !one.blank && one.indent === openIndent && one.body.startsWith('"""');
+
+/**
+ * Reads the tab-indentation errors of an EO program. Each error names the
+ * 1-based line and column 0. A line inside a """ text block is never flagged.
+ * @param {string} text - The whole EO program
+ * @returns {Array<{line: number, column: number, msg: string}>} The errors found
+ */
+export const tabErrors = (text) => {
+  const errors = [];
+  let openIndent = -1;
+  text.split("\n").forEach((line, idx) => {
+    const one = span(line, idx + 1);
+    if (openIndent >= 0) {
+      if (closesTextBlock(one, openIndent)) {
+        openIndent = -1;
+      }
+    } else if (one.tab) {
+      errors.push({ line: one.line, column: 0, msg: "tab character in leading whitespace" });
+    } else if (opensTextBlock(one) && one.indent % 2 === 0) {
+      openIndent = one.indent;
+    }
+  });
+  return errors;
+};
+
+// @todo #352:60 Grow this native port of upstream's Eo.process: add the
+//  "unexpected odd indent" error for a non-blank line whose leading-space count
+//  is odd (right after the tab check, behind the same text-block gate), then
+//  begin a tokens reader that walks each claimed line into its tokens.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,6 +7,7 @@ import { Token as AntlrToken } from "antlr4";
 import { Processor } from "./processor";
 import { ParserError } from "./parserError";
 import { ErrorListener } from "./errorListener";
+import { tabErrors } from "./lines";
 
 /**
  * Set of the token types present in the EO's grammar file
@@ -94,20 +95,12 @@ export function tokenize(input: string): AntlrToken[] {
     return processor.tokens.tokens;
 }
 
-// @todo #352:90 Take the first native step on this seam, top-down and
-//  end-to-end: turn on allowJs and settle the ESM/CommonJS interop so ncc still
-//  bundles src, then add one native-JavaScript module (factory functions, no
-//  classes) that getParserErrors delegates to for a thin real slice of EO
-//  syntax, keeping ANTLR as the fallback for everything else so the existing
-//  tests stay green. Wire it into the diagnostics path so users see genuine
-//  errors from native code, cover the slice with its own test, and leave deeper
-//  puzzles for the line parser, tokens reader and span beneath it.
 /**
- * Parses the input text and returns the parsing errors detected
+ * Parses the input text with ANTLR and returns the parsing errors it detects
  * @param input - Text to be parsed
- * @returns - Array of parsing errors detected during the parsing
+ * @returns - Array of parsing errors detected by ANTLR
  */
-export function getParserErrors(input: string): ParserError[] {
+function antlrErrors(input: string): ParserError[] {
     const processor = new Processor(input);
     const listener = new ErrorListener();
     processor.lexer.removeErrorListeners();
@@ -115,4 +108,18 @@ export function getParserErrors(input: string): ParserError[] {
     processor.parser.addErrorListener(listener);
     processor.parser.program();
     return listener.errors;
+}
+
+/**
+ * Parses the input text and returns the parsing errors detected. At most one
+ * error is reported per line: a line flagged by the native reader suppresses
+ * any error ANTLR raises for the same line.
+ * @param input - Text to be parsed
+ * @returns - Array of parsing errors detected during the parsing
+ */
+export function getParserErrors(input: string): ParserError[] {
+    const native = tabErrors(input)
+        .map(error => new ParserError(error.line, error.column, error.msg));
+    const claimed = new Set(native.map(error => error.line));
+    return native.concat(antlrErrors(input).filter(error => !claimed.has(error.line)));
 }

--- a/test/lines.test.js
+++ b/test/lines.test.js
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { tabErrors } from "../src/lines";
+
+describe("lines", () => {
+  test("flags a line whose indentation starts with a tab", () => {
+    expect(tabErrors("[] > app\n\t42 > @\n")).toEqual([
+      { line: 2, column: 0, msg: "tab character in leading whitespace" }
+    ]);
+  });
+  test("flags a tab hidden after leading spaces", () => {
+    expect(tabErrors("  \tfoo")).toEqual([
+      { line: 1, column: 0, msg: "tab character in leading whitespace" }
+    ]);
+  });
+  test("stays silent on a program indented only with spaces", () => {
+    expect(tabErrors("# app.\n[] > app\n  42 > @\n")).toHaveLength(0);
+  });
+  test("allows tabs inside a text block", () => {
+    expect(tabErrors('[] > app\n  """\n\tnot an error\n  """\n')).toHaveLength(0);
+  });
+  test("does not open a text block on an odd indent, so a later tab is flagged", () => {
+    expect(tabErrors(' """\n\tx\n')).toEqual([
+      { line: 2, column: 0, msg: "tab character in leading whitespace" }
+    ]);
+  });
+  test("does not open a text block when the opener is not bare, so a later tab is flagged", () => {
+    expect(tabErrors('"""x\n\ty\n')).toEqual([
+      { line: 2, column: 0, msg: "tab character in leading whitespace" }
+    ]);
+  });
+  test("ignores blank lines", () => {
+    expect(tabErrors("\n  \n[] > app\n")).toHaveLength(0);
+  });
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -9,7 +9,6 @@ describe("Parser module", () => {
     test("Gets an EO grammar token name from an ANTLR token number", () => {
         expect(antlrTypeNumToString(1)).toBe("COMMENTARY");
     });
-
     test("Retrieves all token type names as defined in EO grammar", () => {
         const types = getTokenTypes();
         expect(types.size).toBe(30);
@@ -19,7 +18,6 @@ describe("Parser module", () => {
         expect(types.has("UNTAB")).toBeFalsy();
         expect(types.has("Q")).toBeFalsy();
     });
-
     test("parses valid code", () => {
         const errors = getParserErrors(
             '# test.\n[] > test\n  42 > @\n  xyz > t\n    "hello, world"\n  bar > foo\n'
@@ -29,12 +27,10 @@ describe("Parser module", () => {
         }
         expect(errors.length).toBe(0);
     });
-
     test("detects parsing errors", () => {
         const errors = getParserErrors("-- broken syntax --");
         expect(errors.length).toBe(1);
     });
-
     test("parses fibonacci program from file", () => {
         const programPath = path.join(__dirname, "../fixtures", "fibonacci.eo");
         const program = fs.readFileSync(programPath, "utf8");
@@ -44,10 +40,25 @@ describe("Parser module", () => {
         }
         expect(errors.length).toBe(0);
     });
-
     test("we expect buildTokenSetAndMap to throw", () => {
         resetTokenCache();
         const location = path.join(__dirname, "none-existing-path", "pathTo.tokens");
         expect(() => buildTokenSetAndMap(location)).toThrow();
+    });
+    test("reports a tab indentation error from the native reader", () => {
+        const errors = getParserErrors("# app.\n[] > app\n\t42 > @\n");
+        expect(errors).toContainEqual(
+            expect.objectContaining({
+                line: 3,
+                column: 0,
+                msg: "tab character in leading whitespace"
+            })
+        );
+    });
+    test("native reader suppresses the ANTLR error on a claimed line", () => {
+        const errors = getParserErrors("# app.\n[] > app\n\t42 > @\n");
+        const online = errors.filter(error => error.line === 3);
+        expect(online).toHaveLength(1);
+        expect(online[0].msg).toBe("tab character in leading whitespace");
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "lib": [
       "es2020"
     ],


### PR DESCRIPTION
First native brick of the EO parser. A new `src/lines.js` reads the program line by line and reports a tab in a line's leading whitespace as an error at column 0. It is a faithful port of upstream's AST-free parser (`Eo.process` / `Span` at eo 0.61.1), down to the detail that tabs stay legal inside `"""` text blocks.

`getParserErrors` now delegates to the native reader and merges the result with ANTLR, which remains the fallback for every other line. The native reader owns the lines it flags, so a tab line shows one clear message instead of ANTLR's cryptic `mismatched input`. `allowJs` lets `tsc` compile the module and `ncc` still bundles `src`.

A puzzle is left for the next slice — upstream's "unexpected odd indent" rule, then a tokens reader beneath it. `make all` is green: 47 tests, full coverage on the new code.

Closes #385
