### PR TITLE
Bring three stale copyright headers up to 2024-2026

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver/node.js";

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { ClientCapabilities } from "vscode-languageserver";

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2024-2025 Objectionary.com
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
 import { ParserError } from "../src/parserError";


### PR DESCRIPTION
Three files that arrived with the diagnostics work — `src/diagnostics.ts`, `test/diagnostics.test.ts` and `test/capabilities.test.ts` — still carried the `2024-2025` copyright line, while the rest of the tree and `LICENSE.txt` had already moved to `2024-2026`.

The copyrights check matches every file against the `LICENSE.txt` punch line verbatim, so a stale year is an inconsistency waiting to break the build the next time the check runs over them. This bumps the three headers to `2024-2026`; nothing else changes.
