### PR TITLE
Tag parser diagnostics with an eo source instead of the placeholder ex

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -24,7 +24,7 @@ export function diagnostics(errors: ParserError[], limit: number, version: strin
                 end: { line: error.line - 1, character: error.column }
             },
             message: `${error.msg} (EO ${version})`,
-            source: "ex"
+            source: "eo"
         });
     });
     return reported;

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -29,4 +29,8 @@ describe("Capped diagnostics builder", () => {
         const errors = [new ParserError(6, 3, "broken token")];
         expect(diagnostics(errors, 1, "0.57.3")[0].message).toBe("broken token (EO 0.57.3)");
     });
+    test("tags the diagnostic with the eo source", () => {
+        const errors = [new ParserError(1, 0, "broken token")];
+        expect(diagnostics(errors, 1, "0.57.3")[0].source).toBe("eo");
+    });
 });


### PR DESCRIPTION
Parser diagnostics were built with `source: "ex"`, the placeholder language name carried over from Microsoft's lsp-sample template. Editors show that string in the Problems panel and on hover, so EO errors were branded with a meaningless name.

The issue points at `server.ts:181`, but the diagnostic-building block has since been extracted into `src/diagnostics.ts` (PR #369), so the line now lives at `diagnostics.ts:27`. This sets it to `"eo"`, matching the project's own config namespace (`settings.eo`) and the `languageId: "eo"` already used in the integration tests, and adds a test that pins the source.

Closes #341
