### PR TITLE
Complete partial workspace config so the diagnostic cap holds

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -8,3 +8,19 @@
 export interface DefaultSettings {
     limit: number;
 }
+
+/**
+ * The settings used when the client supplies none.
+ */
+export const defaultSettings: DefaultSettings = { limit: 1000 };
+
+/**
+ * Completes a raw workspace configuration into full settings, filling every
+ * field the client omitted (such as limit) from the defaults.
+ * @param config - The raw "eo" configuration object from the client, or anything
+ * @returns - Settings with every field present
+ */
+export function settings(config: unknown): DefaultSettings {
+    const partial = config && typeof config === "object" ? config as Partial<DefaultSettings> : {};
+    return { ...defaultSettings, ...partial };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import {
     TextDocumentSyncKind
 } from "vscode-languageserver/node.js";
 import { ClientCapabilitiesAnalyzer } from "./capabilities";
-import { DefaultSettings } from "./defaultSettings";
+import { DefaultSettings, defaultSettings, settings } from "./defaultSettings";
 import { diagnostics } from "./diagnostics";
 import { EoDocumentSymbol } from "./eoDocumentSymbol";
 import { EoVersion } from "./eo-version";
@@ -119,14 +119,9 @@ connection.onInitialized(() => {
 });
 
 /**
- * Settings of the Language Server
- */
-const defaultSettings: DefaultSettings = { limit: 1000 };
-
-/**
  * The global settings, used when the `workspace/configuration` request is not supported by the client.
  */
-let settings: DefaultSettings = defaultSettings;
+let globalSettings: DefaultSettings = defaultSettings;
 
 /**
  * Cache for the settings of all open documents
@@ -140,14 +135,14 @@ const cache: Map<string, Thenable<DefaultSettings>> = new Map();
  */
 function getDocumentSettings(resource: string): Thenable<DefaultSettings> {
     if (!clientCapsAnalyzer.hasConfigurationSupport) {
-        return Promise.resolve(settings);
+        return Promise.resolve(globalSettings);
     }
     let result = cache.get(resource);
     if (!result) {
         result = connection.workspace.getConfiguration({
             scopeUri: resource,
             section: "eo"
-        }).then(config => ((config && typeof config === "object") ? config : defaultSettings));
+        }).then(config => settings(config));
         cache.set(resource, result);
     }
     return result;
@@ -178,7 +173,7 @@ connection.onDidChangeConfiguration(change => {
         cache.clear();
     } else {
         const config = change.settings.eo;
-        settings = (config && typeof config === "object") ? config : defaultSettings;
+        globalSettings = settings(config);
     }
     validateTextDocuments(
         documents.all(),

--- a/test/default-settings.test.ts
+++ b/test/default-settings.test.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+import { settings, defaultSettings } from "../src/defaultSettings";
+
+describe("settings from a raw configuration", () => {
+    test("fills the limit from defaults when the config omits it", () => {
+        expect(settings({}).limit).toBe(defaultSettings.limit);
+    });
+    test("fills the limit when the config carries only unrelated keys", () => {
+        expect(settings({ tabWidth: 4 }).limit).toBe(defaultSettings.limit);
+    });
+    test("keeps the limit the config provides", () => {
+        expect(settings({ limit: 7 }).limit).toBe(7);
+    });
+    test("falls back to defaults when the config is not an object", () => {
+        expect(settings(undefined).limit).toBe(defaultSettings.limit);
+    });
+    test("falls back to defaults when the config is a primitive", () => {
+        expect(settings(5).limit).toBe(defaultSettings.limit);
+    });
+});


### PR DESCRIPTION
When the client's `eo` configuration section is empty or carries only unrelated keys, `workspace/configuration` returns an object with no `limit` field. `getDocumentSettings` passed that object through as `DefaultSettings` unchanged, so `config.limit` was `undefined` at runtime. The diagnostics cap then evaluated `index >= undefined` — that is `index >= NaN`, always false — so the early return never fired and every parser error was published instead of capping at the default of 1000.

This adds `settings()` in `defaultSettings.ts`, which merges any partial config onto the defaults (`{ ...defaultSettings, ...partial }`) so every field is present and typed by the time it is read. Both config paths in `server.ts` now go through it: the `workspace/configuration` resolution and the `onDidChangeConfiguration` fallback. The default value and the helper now live together in `defaultSettings.ts`, keeping the contract in one place.

The issue's `server.ts` line numbers predate the diagnostics extraction in #369, but the mechanism it describes was still live. A unit test covers an empty config, unrelated keys, a provided limit, and non-object inputs.

Closes #376
