### PR TITLE
#362: handle missing semantic token capabilities without crashing on init

### DIFF
--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -46,9 +46,10 @@ export class SemanticTokensProvider {
     /**
      * Sets the map from EO token to VSCode token types and initializes
      * the semantic legend of Semantic Highlighter
-     * @param capability - Capabilities of the semantic tokens client
+     * @param capability - Capabilities of the semantic tokens client, or
+     * undefined when the client advertises no semantic token support
      */
-    constructor(capability: SemanticTokensClientCapabilities) {
+    constructor(capability?: SemanticTokensClientCapabilities) {
         this.setMap(); // must run before computing legend!
         this.legend = this.computeLegend(capability);
     }
@@ -93,11 +94,12 @@ export class SemanticTokensProvider {
     /**
      * For every token in EO's grammar, checks if it is mapped to VSCode token types
      * and, if so, add that token type to the Semantic Tokens Legend of the grammar.
-     * @param capability - Capabilities of the semantic highlighting feature
+     * @param capability - Capabilities of the semantic highlighting feature, or
+     * undefined when the client advertises no semantic token support
      * @returns - Semantic Tokens Legend for the grammar
      */
-    computeLegend(capability: SemanticTokensClientCapabilities): SemanticTokensLegend {
-        const clientTokenTypes = new Set<string>(capability.tokenTypes);
+    computeLegend(capability?: SemanticTokensClientCapabilities): SemanticTokensLegend {
+        const clientTokenTypes = new Set<string>(capability?.tokenTypes);
         const tokenTypes: string[] = [];
         getTokenTypes().forEach(el => {
             const type = this.tokenTypeMap.get(el) || "";

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ let provider: SemanticTokensProvider;
  */
 connection.onInitialize((params: InitializeParams): InitializeResult => {
     clientCapsAnalyzer = new ClientCapabilitiesAnalyzer(params.capabilities);
-    provider = new SemanticTokensProvider(params.capabilities.textDocument!.semanticTokens!);
+    provider = new SemanticTokensProvider(params.capabilities.textDocument?.semanticTokens);
     const result: InitializeResult = {
         capabilities: {
             textDocumentSync: TextDocumentSyncKind.Incremental,

--- a/test/semantics.test.ts
+++ b/test/semantics.test.ts
@@ -115,4 +115,23 @@ describe("Semantics module", () => {
     test("builds an empty legend when the client advertises no semantic token capability", () => {
         expect(new SemanticTokensProvider(undefined).legend.tokenTypes).toStrictEqual([]);
     });
+
+    test("does not throw when constructed without any capability argument", () => {
+        expect(() => new SemanticTokensProvider()).not.toThrow();
+    });
+
+    test("builds an empty legend when the capability omits its token types", () => {
+        const bare = {} as SemanticTokensClientCapabilities;
+        expect(new SemanticTokensProvider(bare).legend.tokenTypes).toStrictEqual([]);
+    });
+
+    test("computeLegend returns an empty legend for a missing capability", () => {
+        expect(provider.computeLegend(undefined).tokenTypes).toStrictEqual([]);
+    });
+
+    test("produces no semantic tokens for a document when the client advertises no capability", () => {
+        const bare = new SemanticTokensProvider(undefined);
+        const document = TextDocument.create("foo.eo", "eo", 0, "# test.\n[] > test\n");
+        expect(bare.tokenize(document)).toStrictEqual([]);
+    });
 });

--- a/test/semantics.test.ts
+++ b/test/semantics.test.ts
@@ -107,4 +107,12 @@ describe("Semantics module", () => {
         populateBuilderSpy.mockRestore();
         builderSpy.mockRestore();
     });
+
+    test("does not throw when the client advertises no semantic token capability", () => {
+        expect(() => new SemanticTokensProvider(undefined)).not.toThrow();
+    });
+
+    test("builds an empty legend when the client advertises no semantic token capability", () => {
+        expect(new SemanticTokensProvider(undefined).legend.tokenTypes).toStrictEqual([]);
+    });
 });


### PR DESCRIPTION
## What happens

In `src/server.ts`, `onInitialize` builds the semantic tokens provider unconditionally:

```ts
provider = new SemanticTokensProvider(params.capabilities.textDocument!.semanticTokens!);
```

When a client does not advertise `semanticTokens` in its capabilities — which is valid per the LSP spec (CLI-based or minimal editors) — that expression is `undefined` at runtime despite the `!` assertions. `SemanticTokensProvider.computeLegend` then runs `new Set(capability.tokenTypes)` on `undefined` and throws `TypeError: Cannot read properties of undefined (reading 'tokenTypes')`, crashing the server at startup and making it unusable for that client.

## What should happen

A client that advertises no semantic token support should initialize normally (with an empty legend) instead of crashing the server.

## Fix

- `SemanticTokensProvider`'s constructor and `computeLegend` now accept an optional capability and read it with `new Set(capability?.tokenTypes)`, so a missing (or partial) capability yields an empty legend rather than a throw.
- `server.ts` passes `params.capabilities.textDocument?.semanticTokens` instead of asserting non-null with `!`, so the type now reflects that the capability may be absent.

The semantic tokens capability is still only *registered* when `clientCapsAnalyzer.hasTokensSupport` is true, so clients that support tokens are unaffected; clients that don't now get a harmless empty-legend provider instead of a crash.

## Tests

Added to `test/semantics.test.ts`, covering the missing-capability path end to end:

- constructing the provider with `undefined` does not throw and yields an empty legend;
- constructing with no argument at all does not throw;
- a capability object that omits `tokenTypes` yields an empty legend;
- `computeLegend(undefined)` returns an empty legend;
- a no-capability provider produces zero semantic tokens for a real document (downstream path stays safe).

## Verification

- `npx jest --coverage` — 11 suites / 63 tests pass; `semantics.ts` at 100%.
- `make lint` — clean.
- `make build` — succeeds.

Closes #362
