### PR TITLE
Handle missing semantic token capabilities without crashing on init

### DIFF
--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -46,9 +46,10 @@ export class SemanticTokensProvider {
     /**
      * Sets the map from EO token to VSCode token types and initializes
      * the semantic legend of Semantic Highlighter
-     * @param capability - Capabilities of the semantic tokens client
+     * @param capability - Capabilities of the semantic tokens client, or
+     * undefined when the client advertises no semantic token support
      */
-    constructor(capability: SemanticTokensClientCapabilities) {
+    constructor(capability?: SemanticTokensClientCapabilities) {
         this.setMap(); // must run before computing legend!
         this.legend = this.computeLegend(capability);
     }
@@ -93,11 +94,12 @@ export class SemanticTokensProvider {
     /**
      * For every token in EO's grammar, checks if it is mapped to VSCode token types
      * and, if so, add that token type to the Semantic Tokens Legend of the grammar.
-     * @param capability - Capabilities of the semantic highlighting feature
+     * @param capability - Capabilities of the semantic highlighting feature, or
+     * undefined when the client advertises no semantic token support
      * @returns - Semantic Tokens Legend for the grammar
      */
-    computeLegend(capability: SemanticTokensClientCapabilities): SemanticTokensLegend {
-        const clientTokenTypes = new Set<string>(capability.tokenTypes);
+    computeLegend(capability?: SemanticTokensClientCapabilities): SemanticTokensLegend {
+        const clientTokenTypes = new Set<string>(capability?.tokenTypes);
         const tokenTypes: string[] = [];
         getTokenTypes().forEach(el => {
             const type = this.tokenTypeMap.get(el) || "";

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ let provider: SemanticTokensProvider;
  */
 connection.onInitialize((params: InitializeParams): InitializeResult => {
     clientCapsAnalyzer = new ClientCapabilitiesAnalyzer(params.capabilities);
-    provider = new SemanticTokensProvider(params.capabilities.textDocument!.semanticTokens!);
+    provider = new SemanticTokensProvider(params.capabilities.textDocument?.semanticTokens);
     const result: InitializeResult = {
         capabilities: {
             textDocumentSync: TextDocumentSyncKind.Incremental,

--- a/test/semantics.test.ts
+++ b/test/semantics.test.ts
@@ -115,4 +115,23 @@ describe("Semantics module", () => {
     test("builds an empty legend when the client advertises no semantic token capability", () => {
         expect(new SemanticTokensProvider(undefined).legend.tokenTypes).toStrictEqual([]);
     });
+
+    test("does not throw when constructed without any capability argument", () => {
+        expect(() => new SemanticTokensProvider()).not.toThrow();
+    });
+
+    test("builds an empty legend when the capability omits its token types", () => {
+        const bare = {} as SemanticTokensClientCapabilities;
+        expect(new SemanticTokensProvider(bare).legend.tokenTypes).toStrictEqual([]);
+    });
+
+    test("computeLegend returns an empty legend for a missing capability", () => {
+        expect(provider.computeLegend(undefined).tokenTypes).toStrictEqual([]);
+    });
+
+    test("produces no semantic tokens for a document when the client advertises no capability", () => {
+        const bare = new SemanticTokensProvider(undefined);
+        const document = TextDocument.create("foo.eo", "eo", 0, "# test.\n[] > test\n");
+        expect(bare.tokenize(document)).toStrictEqual([]);
+    });
 });

--- a/test/semantics.test.ts
+++ b/test/semantics.test.ts
@@ -107,4 +107,12 @@ describe("Semantics module", () => {
         populateBuilderSpy.mockRestore();
         builderSpy.mockRestore();
     });
+
+    test("does not throw when the client advertises no semantic token capability", () => {
+        expect(() => new SemanticTokensProvider(undefined)).not.toThrow();
+    });
+
+    test("builds an empty legend when the client advertises no semantic token capability", () => {
+        expect(new SemanticTokensProvider(undefined).legend.tokenTypes).toStrictEqual([]);
+    });
 });


### PR DESCRIPTION
When a language client connects without advertising `textDocument.semanticTokens`, the server dies on startup. `onInitialize` builds the `SemanticTokensProvider` from `params.capabilities.textDocument!.semanticTokens!`, but that value is really `undefined` for CLI and minimal editors, which is perfectly valid per the LSP spec. `computeLegend` then runs `new Set(capability.tokenTypes)` on it and throws a `TypeError`, leaving the client with a dead server.

The provider now treats the capability as optional and reads `capability?.tokenTypes`, so a missing or partial capability yields an empty legend instead of throwing. `onInitialize` passes `params.capabilities.textDocument?.semanticTokens` and drops the two misleading non-null assertions. The feature is still only registered when the client actually supports semantic tokens, so nothing changes for clients that do.

The added tests in `test/semantics.test.ts` cover the missing and partial capability paths, including that a provider built without a capability produces no tokens for a real document.

Closes #362
