### PR TITLE
Flag odd indents and begin the native tokens reader

### DIFF
--- a/src/lines.js
+++ b/src/lines.js
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
+import { tokens } from "./tokens";
+
 /**
  * Reads one source line into its indentation facts.
  * @param {string} text - One line, without its newline terminator
@@ -45,13 +47,14 @@ const closesTextBlock = (one, openIndent) =>
   !one.blank && one.indent === openIndent && one.body.startsWith('"""');
 
 /**
- * Reads the tab-indentation errors of an EO program. Each error names the
- * 1-based line and column 0. A line inside a """ text block is never flagged.
+ * Walks an EO program once, gathering leading-whitespace errors and the tokens
+ * of each claimed line. Lines inside a """ block are never flagged.
  * @param {string} text - The whole EO program
- * @returns {Array<{line: number, column: number, msg: string}>} The errors found
+ * @returns Errors and tokens gathered from the program
  */
-export const tabErrors = (text) => {
+const walk = (text) => {
   const errors = [];
+  const found = [];
   let openIndent = -1;
   text.split("\n").forEach((line, idx) => {
     const one = span(line, idx + 1);
@@ -61,14 +64,27 @@ export const tabErrors = (text) => {
       }
     } else if (one.tab) {
       errors.push({ line: one.line, column: 0, msg: "tab character in leading whitespace" });
-    } else if (opensTextBlock(one) && one.indent % 2 === 0) {
+    } else if (!one.blank && one.indent % 2 === 1) {
+      errors.push({ line: one.line, column: 0, msg: "unexpected odd indent" });
+    } else if (opensTextBlock(one)) {
       openIndent = one.indent;
+    } else if (!one.blank && one.body[0] >= "a" && one.body[0] <= "z") {
+      found.push(tokens(one).readName());
     }
   });
-  return errors;
+  return { errors, tokens: found };
 };
 
-// @todo #352:60 Grow this native port of upstream's Eo.process: add the
-//  "unexpected odd indent" error for a non-blank line whose leading-space count
-//  is odd (right after the tab check, behind the same text-block gate), then
-//  begin a tokens reader that walks each claimed line into its tokens.
+/**
+ * Reads the leading-whitespace errors of an EO program.
+ * @param {string} text - The whole EO program
+ * @returns The errors found
+ */
+export const lineErrors = (text) => walk(text).errors;
+
+/**
+ * Reads the head token of each claimed line.
+ * @param {string} text - The whole EO program
+ * @returns The tokens found
+ */
+export const lineTokens = (text) => walk(text).tokens;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,7 +7,7 @@ import { Token as AntlrToken } from "antlr4";
 import { Processor } from "./processor";
 import { ParserError } from "./parserError";
 import { ErrorListener } from "./errorListener";
-import { tabErrors } from "./lines";
+import { lineErrors } from "./lines";
 
 /**
  * Set of the token types present in the EO's grammar file
@@ -118,7 +118,7 @@ function antlrErrors(input: string): ParserError[] {
  * @returns - Array of parsing errors detected during the parsing
  */
 export function getParserErrors(input: string): ParserError[] {
-    const native = tabErrors(input)
+    const native = lineErrors(input)
         .map(error => new ParserError(error.line, error.column, error.msg));
     const claimed = new Set(native.map(error => error.line));
     return native.concat(antlrErrors(input).filter(error => !claimed.has(error.line)));

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+/** Characters that terminate a NAME token. */
+const TERMINATORS = new Set([
+  " ", "\t", ",", ".", "|", "'", ":", ";", "!", "?", "]", "[", "}", "{", ")", "("
+]);
+
+/**
+ * A stream-style token reader over one claimed line's body. Positions are
+ * absolute columns, already offset by the line's indent.
+ * @param {{line: number, indent: number, body: string}} one - The claimed span
+ * @returns Tokens reader object
+ */
+export const tokens = (one) => {
+  const body = one.body;
+  let cursor = 0;
+  /**
+   * Read a NAME at the cursor; the caller guarantees a lowercase head.
+   * @returns The identifier token
+   */
+  const readName = () => {
+    const start = cursor;
+    cursor += 1;
+    while (cursor < body.length && !TERMINATORS.has(body[cursor])) {
+      cursor += 1;
+    }
+    return {
+      line: one.line,
+      start: one.indent + start,
+      length: cursor - start,
+      kind: "identifier",
+      raw: body.slice(start, cursor)
+    };
+  };
+  return { readName };
+};
+
+// @todo #389:60 Grow the tokens reader: teach it the remaining value shapes
+//  (STRING, INT/FLOAT, HEX, BYTES, ROOT, STAR and paren groups), then
+//  method-dispatch chains and horizontal argument lists, and finally wire
+//  lineTokens into semantic highlighting (src/parser.ts tokenize/getTokenTypes)
+//  so ANTLR stops owning the token stream.

--- a/test/lines.test.js
+++ b/test/lines.test.js
@@ -1,36 +1,55 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-import { tabErrors } from "../src/lines";
+import { lineErrors, lineTokens } from "../src/lines";
 
-describe("lines", () => {
+describe("lineErrors", () => {
   test("flags a line whose indentation starts with a tab", () => {
-    expect(tabErrors("[] > app\n\t42 > @\n")).toEqual([
+    expect(lineErrors("[] > app\n\t42 > @\n")).toEqual([
       { line: 2, column: 0, msg: "tab character in leading whitespace" }
     ]);
   });
   test("flags a tab hidden after leading spaces", () => {
-    expect(tabErrors("  \tfoo")).toEqual([
+    expect(lineErrors("  \tfoo")).toEqual([
       { line: 1, column: 0, msg: "tab character in leading whitespace" }
     ]);
   });
-  test("stays silent on a program indented only with spaces", () => {
-    expect(tabErrors("# app.\n[] > app\n  42 > @\n")).toHaveLength(0);
+  test("flags a non-blank line whose leading-space count is odd", () => {
+    expect(lineErrors("[] > app\n   42 > @\n")).toEqual([
+      { line: 2, column: 0, msg: "unexpected odd indent" }
+    ]);
+  });
+  test("stays silent on a program indented only with even spaces", () => {
+    expect(lineErrors("# app.\n[] > app\n  42 > @\n")).toHaveLength(0);
   });
   test("allows tabs inside a text block", () => {
-    expect(tabErrors('[] > app\n  """\n\tnot an error\n  """\n')).toHaveLength(0);
+    expect(lineErrors('[] > app\n  """\n\tnot an error\n  """\n')).toHaveLength(0);
   });
-  test("does not open a text block on an odd indent, so a later tab is flagged", () => {
-    expect(tabErrors(' """\n\tx\n')).toEqual([
+  test("flags the odd indent of a would-be opener, so the block never opens", () => {
+    expect(lineErrors(' """\n\tx\n')).toEqual([
+      { line: 1, column: 0, msg: "unexpected odd indent" },
       { line: 2, column: 0, msg: "tab character in leading whitespace" }
     ]);
   });
   test("does not open a text block when the opener is not bare, so a later tab is flagged", () => {
-    expect(tabErrors('"""x\n\ty\n')).toEqual([
+    expect(lineErrors('"""x\n\ty\n')).toEqual([
       { line: 2, column: 0, msg: "tab character in leading whitespace" }
     ]);
   });
   test("ignores blank lines", () => {
-    expect(tabErrors("\n  \n[] > app\n")).toHaveLength(0);
+    expect(lineErrors("\n  \n[] > app\n")).toHaveLength(0);
+  });
+});
+
+describe("lineTokens", () => {
+  test("reads the head NAME up to its terminator, offset by the line indent", () => {
+    expect(lineTokens("[] > app\n  fibonacci n\n")).toEqual([
+      { line: 2, start: 2, length: 9, kind: "identifier", raw: "fibonacci" }
+    ]);
+  });
+  test("reads a NAME to the line end and claims nothing from other lines", () => {
+    expect(lineTokens("foo\n# app.\n\n[] > app\n")).toEqual([
+      { line: 1, start: 0, length: 3, kind: "identifier", raw: "foo" }
+    ]);
   });
 });


### PR DESCRIPTION
This grows the native line parser toward the spec-driven Eo.process walk, and it does two things.

First, a non-blank line whose leading-space count is odd now reports "unexpected odd indent". The check sits right after the tab rule and behind the same text-block gate, so a bare """ opener sitting at an odd indent gets flagged rather than silently opening a block. The error flows through getParserErrors into the diagnostics the editor already renders.

Second, it begins a small tokens reader. It is a stream-style reader over one claimed line's body that reads the head NAME token, and the line walk hands each claimed code line to it. Positions come back as absolute columns, so wiring it into semantic highlighting later is a short step.

A puzzle is left in src/tokens.js to grow the reader to the remaining value shapes, then method-dispatch chains and argument lists, and finally to take over the token stream from ANTLR.

Closes #389.
